### PR TITLE
[BACK_END] Update `max-lines-per-function`

### DIFF
--- a/packages/backend/config.json
+++ b/packages/backend/config.json
@@ -38,7 +38,11 @@
     ],
     "max-lines-per-function": [
       "error",
-      20
+      {
+        "max": 20,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
     ],
     "max-len": [
       "error",


### PR DESCRIPTION
Enable the options `skipBlankLines` and `skipComments` for the `max-lines-per-function` on the back-end package.