### PR TITLE
Atualizações no linter de fundamentos

### DIFF
--- a/packages/fundamentals/config.json
+++ b/packages/fundamentals/config.json
@@ -9,6 +9,7 @@
     "editorconfig"
   ],
   "rules": {
+    "no-restricted-syntax": "off",
     "editorconfig/editorconfig": "error",
     "no-console": "off",
     "no-alert": "off",

--- a/packages/fundamentals/config.json
+++ b/packages/fundamentals/config.json
@@ -41,7 +41,7 @@
     ],
     "max-lines-per-function": [
       "error",
-      20
+      50
     ],
     "max-len": [
       "error",

--- a/packages/fundamentals/config.json
+++ b/packages/fundamentals/config.json
@@ -42,7 +42,11 @@
     ],
     "max-lines-per-function": [
       "error",
-      50
+      {
+        "max": 20,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
     ],
     "max-len": [
       "error",


### PR DESCRIPTION
Nesse PR, alteramos:
- Desabilita linha em branco e comentários da contagem de quantidades de linha numa função
- Desabilitamos a regra `no-restricted-syntax`