### PR TITLE
Torna fixas as versões de dependências dos pacotes

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,10 +11,10 @@
   "author": "Roz <roz@rjmunhoz.me>",
   "license": "GPL-3.0",
   "dependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb": "^18.2.1",
-    "eslint-plugin-editorconfig": "^3.0.1",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-sonarjs": "^0.5.0"
+    "eslint": "6.8.0",
+    "eslint-config-airbnb": "18.2.1",
+    "eslint-plugin-editorconfig": "3.0.1",
+    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-sonarjs": "0.5.0"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,13 +12,13 @@
   "license": "GPL-3.0",
   "dependencies": {
     "eslint": "6.8.0",
-    "eslint-config-airbnb": "^18.2.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-func": "^0.1.17",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "eslint-plugin-react-redux": "^3.3.0",
-    "eslint-plugin-sonarjs": "^0.5.0"
+    "eslint-config-airbnb": "18.2.0",
+    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jsx-a11y": "6.4.1",
+    "eslint-plugin-react": "7.21.5",
+    "eslint-plugin-react-func": "0.1.17",
+    "eslint-plugin-react-hooks": "1.7.0",
+    "eslint-plugin-react-redux": "3.3.0",
+    "eslint-plugin-sonarjs": "0.5.0"
   }
 }

--- a/packages/fundamentals/package.json
+++ b/packages/fundamentals/package.json
@@ -11,10 +11,10 @@
   "author": "Roz <roz@rjmunhoz.me>",
   "license": "GPL-3.0",
   "dependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb": "^18.2.0",
-    "eslint-plugin-editorconfig": "^2.1.3",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-sonarjs": "^0.5.0"
+    "eslint": "6.8.0",
+    "eslint-config-airbnb": "18.2.0",
+    "eslint-plugin-editorconfig": "2.1.3",
+    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-sonarjs": "0.5.0"
   }
 }


### PR DESCRIPTION
Não ter versões fixas pode trazer problemas quando estudantes tentam utilizar o linter localmente, visto que acabam por utilizar versões diferentes das que testamos e validamos.
Essa mesma alteração já foi realizada para as dependências dos projetos, por exemplo.
