### PR TITLE
Desabilitar regra state in constructor

### DIFF
--- a/packages/frontend/config.json
+++ b/packages/frontend/config.json
@@ -241,8 +241,7 @@
       "error"
     ],
     "react/state-in-constructor": [
-      "error",
-      "always"
+      "off"
     ],
     "react/void-dom-elements-no-children": [
       "error"


### PR DESCRIPTION
Essa regra não deixa as pessoas estudantes escreverem assim, pois exige que o estado seja inicializado no construtor.

```javascript
class App extends React.Component {
  state = {
    name: 'Lalaland'
  }
}

```

Entretanto, com a nova sintaxe de Public Class Fields isso é possível e inclusive é recomendado pelo mantenedor do React e criador do Redux Dan Abramov:  (fonte: https://overreacted.io/pt-br/why-do-we-write-super-props/)

> Uma sintaxe como essa foi planejada quando o React 0.13 passou a dar suporte a classes em 2015. Definir o constructor e invocar o super(props) desde sempre foi pensada como uma solução temporária até que os atributos das classes oferecessem uma alternativa mais ergonômica.