### PR TITLE
Frontend: Version 1.3.0

### DIFF
--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **frontend:** bump versions for all dependencies (ESLint v8)
 * **frontend:** Resolves bug with `create-react-app` v5. (removes babel parser)
 * **frontend:** Added peerDependencies - now sonarJS is installed automatically 😋 (and other benefits)
+* **frontend:** Rule: 'default-param-last' is OFF
 * **frontend:** Rule: 'React' must be in scope when using JSX is now OFF
 * **frontend:** Eslint no longer runs in cypress folder! "ignorePatterns": ["cypress/*"],
 * **frontend:** Ecmaversion now is 2022

--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3](https://github.com/betrybe/eslint-config-trybe/compare/eslint-config-trybe-frontend@1.2.3...eslint-config-trybe-frontend@1.3.0) (2022-07-28)
+
+* **frontend:** bump versions for all dependencies (ESLint v8)
+* **frontend:** Resolves bug with `create-react-app` v5. (removes babel parser)
+* **frontend:** Added peerDependencies - now sonarJS is installed automatically 😋 (and other benefits)
+* **frontend:** Rule: 'React' must be in scope when using JSX is now OFF
+* **frontend:** Eslint no longer runs in cypress folder! "ignorePatterns": ["cypress/*"],
+* **frontend:** Ecmaversion now is 2022
+
+
 ## [1.2.3](https://github.com/betrybe/eslint-config-trybe/compare/eslint-config-trybe-frontend@1.2.2...eslint-config-trybe-frontend@1.2.3) (2022-02-01)
 
 **Note:** Version bump only for package eslint-config-trybe-frontend

--- a/packages/frontend/config.json
+++ b/packages/frontend/config.json
@@ -333,6 +333,7 @@
     ],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn", 
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "default-param-last": "off"
   }
 }

--- a/packages/frontend/config.json
+++ b/packages/frontend/config.json
@@ -1,7 +1,7 @@
 {
   "env": {
     "browser": true,
-    "es2020": true
+    "es2022": true
   },
   "extends": [
     "plugin:react/recommended",
@@ -12,6 +12,7 @@
     "ecmaFeatures": {
       "jsx": true
     },
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "plugins": [
@@ -21,7 +22,7 @@
     "sonarjs",
     "react-func"
   ],
-  "parser": "babel-eslint", 
+  "ignorePatterns": ["cypress/*"], 
   "rules": {
     "indent": [
       "error",
@@ -331,6 +332,7 @@
       "error"
     ],
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn", 
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-trybe-frontend",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "ESLint shared config used by Trybe on frontend projects",
   "main": "config.json",
   "keywords": [
@@ -8,18 +8,28 @@
     "trybe",
     "frontend"
   ],
-  "author": "Roz <roz@rjmunhoz.me>",
+  "author": "Equipe Front",
   "license": "GPL-3.0",
-  "dependencies": {
-    "babel-eslint": "^10.1.0",
-    "eslint": "6.8.0",
-    "eslint-config-airbnb": "^18.2.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.21.5",
+  "devDependencies": {
+    "eslint": "^8.20.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
+    "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-func": "^0.1.17",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "eslint-plugin-react-redux": "^3.3.0",
-    "eslint-plugin-sonarjs": "^0.5.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-redux": "^4.0.0",
+    "eslint-plugin-sonarjs": "^0.14.0"
+  },
+  "peerDependencies": {
+    "eslint": "^8.20.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
+    "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react-func": "^0.1.17",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-redux": "^4.0.0",
+    "eslint-plugin-sonarjs": "^0.14.0"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,25 +11,25 @@
   "author": "Equipe Front",
   "license": "GPL-3.0",
   "devDependencies": {
-    "eslint": "^8.20.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsx-a11y": "^6.6.1",
-    "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-func": "^0.1.17",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-redux": "^4.0.0",
-    "eslint-plugin-sonarjs": "^0.14.0"
+    "eslint": "8.20.0",
+    "eslint-config-airbnb": "19.0.4",
+    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-jsx-a11y": "6.6.1",
+    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react-func": "0.1.17",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-react-redux": "4.0.0",
+    "eslint-plugin-sonarjs": "0.14.0"
   },
   "peerDependencies": {
-    "eslint": "^8.20.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsx-a11y": "^6.6.1",
-    "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-func": "^0.1.17",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-redux": "^4.0.0",
-    "eslint-plugin-sonarjs": "^0.14.0"
+    "eslint": "8.20.0",
+    "eslint-config-airbnb": "19.0.4",
+    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-jsx-a11y": "6.6.1",
+    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react-func": "0.1.17",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-react-redux": "4.0.0",
+    "eslint-plugin-sonarjs": "0.14.0"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "trybe",
     "frontend"
   ],
-  "author": "Equipe Front",
+  "author": "Equipe Front Trybe",
   "license": "GPL-3.0",
   "devDependencies": {
     "eslint": "8.20.0",


### PR DESCRIPTION
* **frontend:** bump versions for all dependencies (ESLint v8)
* **frontend:** Resolves bug with `create-react-app` v5. (removes babel parser)
* **frontend:** Added peerDependencies - now sonarJS is installed automatically 😋 (and other benefits)
* **frontend:** Rule: 'React' must be in scope when using JSX is now OFF
* **frontend:** Eslint no longer runs in cypress folder! "ignorePatterns": ["cypress/*"],
* **frontend:** Ecmaversion now is 2022


Criado por @robertotcestari @MurilloWolf @bruno-alves7 @DanielFariias @programadorEmerson @ANDREHORMAN1994 