### PR TITLE
Default Props - React

### DIFF
--- a/packages/frontend/config.json
+++ b/packages/frontend/config.json
@@ -85,6 +85,12 @@
         "allowRequiredDefaults": false
       }
     ],
+    "react/require-default-props": [
+      "error",
+      {
+        "functions": "defaultArguments"
+      }
+    ],
     "react/no-array-index-key": ["off"],
     "react/destructuring-assignment": ["error", "always"],
     "react/forbid-component-props": ["error"],


### PR DESCRIPTION
Aqui faz sentido adicionarmos um argumento à regra require-default-props: para componentes funcionais não é recomendado o defaultProps, mas apenas colcarmos default parameters
